### PR TITLE
Fix SerialPort to support current version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
   },
   "dependencies": {
     "async": "^1.5.0",
+    "body-parser": "^1.12.4",
     "express": "^4.12.4",
     "morgan": "^1.6.1",
-    "body-parser": "^1.12.4",
-    "serialport": "^2.0.2"
+    "serialport": "^7.0.2"
   }
 }


### PR DESCRIPTION
```parser: serialport.parsers.readline("\n")``` Is no longer supported. Hopefully these changes makes it easier for others who use this project. 