### PR TITLE
terminate the process when command error is met

### DIFF
--- a/app.js
+++ b/app.js
@@ -49,6 +49,9 @@ connection.on("open", function () {
 
   parser.on('data', function (data) {
     console.log(data);
+    if (data.startsWith('Command Error.')) { // returned from amp device
+      process.exit(-1);
+    }
     var zone = data.toString("ascii").match(/#>(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/);
     if (zone != null) {
       zones[zone[1]] = {
@@ -187,7 +190,7 @@ connection.on("open", function () {
         function (callback) { setTimeout(callback, 10); }
       );
     }
-      writeAttribute();
+    writeAttribute();
     queryControllers();
     async.until(
       function (callback) { callback(null, typeof zones[req.zone] !== "undefined"); },

--- a/app.js
+++ b/app.js
@@ -50,7 +50,7 @@ connection.on("open", function () {
   parser.on('data', function (data) {
     console.log(data);
     if (data.startsWith('Command Error.')) { // returned from amp device
-      process.exit(-1);
+      process.exit(1);
     }
     var zone = data.toString("ascii").match(/#>(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/);
     if (zone != null) {


### PR DESCRIPTION
# Adds
+ an aboard if the amp returns a 'Command Error.' (_in testing at higher baud rates you can get byte error and the Amp returns a 'Command Error.' - the fast fix here is to have the process terminate as the Amp will never fulfill the request and the request will hang.  Open to better solutions._)