### PR TITLE
Delay extra init sequence for second and third amps

### DIFF
--- a/app.js
+++ b/app.js
@@ -38,8 +38,12 @@ connection.on("open", function () {
   }
 
   connection.write("?10\r");
-  AmpCount >= 2 && connection.write("?20\r");
-  AmpCount >= 3 && connection.write("?30\r");
+  if(AmpCount >= 2){
+    setTimeout(function(){ connection.write("?20\r"); }, 1000);
+  }
+  if(AmpCount >= 3){
+    setTimeout(function(){ connection.write("?30\r"); }, 2000);
+  }
 
   UseCORS && app.use(function (req, res, next) {
     res.header("Access-Control-Allow-Origin", "*");


### PR DESCRIPTION
For the last year or so I've been using this repo in a project at home.  Today I added a second controller, and it doesn't always work.  It worked on first start-up, but now after resetting everything it's struggling to start, and I believe it is because of the back-to-back writes here:
https://github.com/jnewland/mpr-6zhmaut-api/blob/71d05bb0c6dd1ac28b9e0e3f17ca65feb11869b7/app.js#L41

You can see the ?10 goes through, and then instead of ?20, you just get 20.  

If you look in the below logs, the missing ? ends up randomly in the output for zones 3, 4, or 5 sometimes.  It seems as though a delay is missing.  In this commit I've added a simple 1s delay between the inits for zones 2 and 3, and that seems to do the trick.


Logs:
Starting the mono api!
?10
#>1100000000080707100100
#>1200000000080707100100
#>1300000000080707?000100
#>1400000000080707100100
#>1500000000080707100100
#>1600000000080707100100
#20
#
Command Error.
Starting the mono api!
?10
#>1100000000080707100100
#>1200000000080707100100
#>1300000000080707100100
#>1400000000?080707100100
#>1500000000080707100100
#>1600000000080707100100
#20
#
Command Error.
Starting the mono api!
?10
#>1100000000080707100100
#>1200000000080707100100
#>1300000000080707100100
#>1400000000?080707100100
#>1500000000080707100100
#>1600000000080707100100
#20
#
Command Error.
Starting the mono api!
?10
#>1100000000080707100100
#>1200000000080707100100
#>1300000000080707100100
#>1400000000080707100100
#>150000000?0080707100100
#>1600000000080707100100
#20
#
Command Error.
